### PR TITLE
Keep copy of original vsftpd.conf file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'tomatrollnorocksdotcom'
 license          'GPL 2'
 description      'Installs/Configures vsftpd package'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'
 
 supports "ubuntu", "14.04"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,4 @@
-  #
+#
 # Cookbook Name:: basic_vsftpd
 # Recipe:: default
 #
@@ -7,13 +7,22 @@
 # All rights reserved - Do Not Redistribute
 #
 
-package "vsftpd"
+package 'vsftpd'
 
 vsftpd_config_file = value_for_platform_family(
   'rhel'   => '/etc/vsftpd/vsftpd.conf',
   'debian' => '/etc/vsftpd.conf',
   'default' => '/etc/vsftpd.conf'
 )
+
+remote_file 'Copy original vsftpd config' do
+  path "#{vsftpd_config_file}.orig"
+  source "file://#{vsftpd_config_file}"
+  owner 'root'
+  group 'root'
+  mode '0400'
+  action :create_if_missing
+end
 
 template vsftpd_config_file do
   source 'vsftpd.conf.erb'

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -12,6 +12,10 @@ describe 'basic_vsftpd::default' do
 
   describe 'the vsftpd.conf file' do
     let(:config_file) {'/etc/vsftpd.conf'}
+    let(:config_orig) {'/etc/vsftpd.conf.orig'}
+    it 'original contents are copied' do
+      expect(subject).to create_remote_file_if_missing(config_orig)
+    end
     it 'is created' do
       expect(subject).to create_template(config_file)
     end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -7,6 +7,10 @@ describe service('vsftpd') do
   it { should be_running }
 end
 
+describe file('/etc/vsftpd.conf.orig') do
+  it { should be_file }
+end
+
 describe file('/etc/vsftpd.conf') do
   it { should be_file }
   it { should contain('chroot_list_file=/etc/vsftpd.chroot_list')}


### PR DESCRIPTION
Fixes #1 

```
Changes:

1. Version bump to 0.1.3.
2. Make a copy of original vsftpd config for reference.
3. Add kitchen and chefspec coverage.
4. Fixed some rubocop offences in default.rb.
```
